### PR TITLE
Correct a wrong word

### DIFF
--- a/src/commands/contracts/money-market-liquidation.ts
+++ b/src/commands/contracts/money-market-liquidation.ts
@@ -175,7 +175,7 @@ interface Bid {
 const getBid = query
   .command('bid')
   .description(
-    "Get information about the specifed bidder's bid for the specified collateral",
+    "Get information about the specified bidder's bid for the specified collateral",
   )
   .requiredOption(
     '--collateral-token <AccAddress>',


### PR DESCRIPTION
Correct a wrong word 'specifed' to 'specified'

Happy to contribute a small thing.